### PR TITLE
bug-[IN-4]: fixed save theme to rerender

### DIFF
--- a/src/_app/Providers/Theme/Theme.tsx
+++ b/src/_app/Providers/Theme/Theme.tsx
@@ -1,6 +1,7 @@
-import {ReactNode} from 'react'
+import {ReactNode, useEffect, useState} from 'react'
 
-import {useAppSelector} from '@/shared/hooks/reduxHooks'
+import {setThemeAppAC} from '@/_app/Store/slices/appSlice'
+import {useAppDispatch, useAppSelector} from '@/shared/hooks/reduxHooks'
 import {GlobalStyles, ToastContainerStyled, darkTheme, lightTheme} from '@nazar-pryt/inctagram-ui-kit'
 import {Inter} from 'next/font/google'
 import {ThemeProvider} from 'styled-components'
@@ -8,7 +9,19 @@ import {ThemeProvider} from 'styled-components'
 const inter = Inter({subsets: ['latin']})
 
 export function Theme({children}: {children: ReactNode}) {
-    const theme = useAppSelector(state => state.app.theme)
+    const dispatch = useAppDispatch()
+
+    const themeApp = useAppSelector(state => state.app.theme)
+    const [theme, setTheme] = useState('')
+
+    useEffect(() => {
+        const themeLocal = localStorage.getItem('themeSwitcher')
+
+        if (themeLocal) {
+            setTheme(themeLocal)
+            dispatch(setThemeAppAC({theme: themeLocal === 'light' ? 'light' : 'dark'}))
+        }
+    }, [themeApp])
 
     return (
         <ThemeProvider theme={theme === 'light' ? lightTheme : darkTheme}>

--- a/src/_app/Store/slices/appSlice.ts
+++ b/src/_app/Store/slices/appSlice.ts
@@ -31,6 +31,7 @@ export const appSlice = createSlice({
         },
         setThemeAppAC: (state, action: PayloadAction<{theme: ThemeAppType}>) => {
             state.theme = action.payload.theme
+            localStorage.setItem('themeSwitcher', action.payload.theme)
         },
     },
 })

--- a/src/features/ThemeSwitcher/ThemeSwitcher.tsx
+++ b/src/features/ThemeSwitcher/ThemeSwitcher.tsx
@@ -1,16 +1,27 @@
+import {useEffect, useState} from 'react'
+
 import {setThemeAppAC} from '@/_app/Store/slices/appSlice'
 import {useAppDispatch, useAppSelector} from '@/shared/hooks/reduxHooks'
-import {IconButton, MoonIcon, SunIcon} from '@nazar-pryt/inctagram-ui-kit'
+import {IconButton, MoonIcon, SunIcon, ThemeAppType} from '@nazar-pryt/inctagram-ui-kit'
 
 export const ThemeSwitcher = () => {
     const dispatch = useAppDispatch()
-    const themeApp = useAppSelector(state => state.app.theme)
-
+    const themeState = useAppSelector(state => state.app.theme)
+    const [themeApp, setThemeApp] = useState(themeState)
     const theme = themeApp === 'light' ? 'dark' : 'light'
 
     const handleThemeChange = () => {
         dispatch(setThemeAppAC({theme}))
+        setThemeApp(theme as ThemeAppType)
     }
+
+    useEffect(() => {
+        const themeLocal = localStorage.getItem('themeSwitcher')
+
+        if (themeLocal) {
+            setThemeApp(themeLocal as ThemeAppType)
+        }
+    }, [themeApp])
 
     return (
         <>


### PR DESCRIPTION
Pull request type
◦ [ ] Feature
◦ [ ] Code style update (formatting, local variables)
◦ [ x ] Refactoring (no functional changes, no api changes)
◦ [ x ] Fix
◦ [ x ] Bug
◦ [ ] Build related changes
◦ [ ] Documentation update
◦ [ ] Tests
◦ [ ] Other

• What’s new?
◦ merge and update 'dev' branch into this branch ( 'sergio/IN-4-save-theme' )
◦ upgraded dependencies from package.json
◦ added storageKey to localStorage for save theme 
◦ added to appSlice set value storageKey
◦ fix logic get theme into ThemeProvider

• Related Issues:
◦ closes [IN-4](https://ockap91.atlassian.net/browse/IN-4)

• Checklist before merge
◦ [x] This pull request merges to the current sprint branch
◦ [x] I have reviewed the code for potential issues
◦ [x] I have fixed any warnings or errors
◦ [ ] Approved by team developers

• How it works and Prewiews:
 In the ThemeSwitcher, when you click on the icon, the value in storageKey localStorage   is assigned. 
After this, in the Theme file the values from storageKey localStorage are assigned to theme into ThemeProvider


